### PR TITLE
Fix bug

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1038,7 +1038,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.actions.fitWidth.setChecked(False)
         self.actions.fitWindow.setChecked(False)
         self.zoom_mode = self.MANUAL_ZOOM
-        self.zoom_widget.setValue(value)
+        self.zoom_widget.setValue(int(value))
 
     def add_zoom(self, increment=10):
         self.set_zoom(self.zoom_widget.value() + increment)
@@ -1089,8 +1089,8 @@ class MainWindow(QMainWindow, WindowMixin):
         d_v_bar_max = v_bar.maximum() - v_bar_max
 
         # get the new scrollbar values
-        new_h_bar_value = h_bar.value() + move_x * d_h_bar_max
-        new_v_bar_value = v_bar.value() + move_y * d_v_bar_max
+        new_h_bar_value = int(h_bar.value() + move_x * d_h_bar_max)
+        new_v_bar_value = int(v_bar.value() + move_y * d_v_bar_max)
 
         h_bar.setValue(new_h_bar_value)
         v_bar.setValue(new_v_bar_value)

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -301,17 +301,17 @@ class Canvas(QWidget):
             pos = self.transform_pos(ev.pos())
             if self.drawing():
                 self.handle_drawing(pos)
-
-                if len(self.shapes) == 0:
-                    return
-
-                if self.shapes[-1].area < self.limit_size(self.shapes[-1].label):
-                    self.parent().window().remove_label(self.shapes[-1])
-                    self.shapes.remove(self.shapes[-1])
-                    self.update()
             else:
                 # pan
                 QApplication.restoreOverrideCursor()
+
+            if len(self.shapes) == 0:
+                return
+
+            if self.shapes[-1].area < self.limit_size(self.shapes[-1].label):
+                self.parent().window().remove_label(self.shapes[-1])
+                self.shapes.remove(self.shapes[-1])
+                self.update()
 
     def end_move(self, copy=False):
         assert self.selected_shape and self.selected_shape_copy

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -64,11 +64,17 @@ class Canvas(QWidget):
         self.verified = False
         self.draw_square = False
         self.label = None
-        self.bd_limit_size = 50
-        self.limit_size = 10
 
         # initialisation for panning
         self.pan_initial_pos = QPoint()
+
+    def limit_size(self, cat=None):
+        if cat == 'BD':
+            return 150
+        elif cat == 'PH':
+            return 50
+        else:
+            return 10
 
     def set_drawing_color(self, qcolor):
         self.drawing_line_color = qcolor
@@ -162,6 +168,12 @@ class Canvas(QWidget):
                 else:
                     self.line[1] = pos
 
+                if width * height < self.limit_size(self.label):
+                    color = self.drawing_bad_color
+                else:
+                    color = self.drawing_line_color
+
+                self.drawing_rect_color = color
                 self.line.line_color = color
                 self.prev_point = QPointF()
                 self.current.highlight_clear()
@@ -184,6 +196,15 @@ class Canvas(QWidget):
         # Polygon/Vertex moving.
         if Qt.LeftButton & ev.buttons():
             if self.selected_vertex():
+                if self.selected_shape.area < self.limit_size(self.label):
+                    self.drawing_rect_color = self.drawing_bad_color
+                    self.line.line_color = self.drawing_bad_color
+                    self.selected_shape.select_fill_color = self.drawing_bad_fill_color
+                else:
+                    self.drawing_rect_color = self.drawing_rect_color
+                    self.line.line_color = self.drawing_line_color
+                    self.selected_shape.select_fill_color = DEFAULT_SELECT_FILL_COLOR
+
                 self.bounded_move_vertex(pos)
                 self.shapeMoved.emit()
                 self.repaint()
@@ -267,12 +288,27 @@ class Canvas(QWidget):
         elif ev.button() == Qt.LeftButton and self.selected_shape:
             if self.selected_vertex():
                 self.override_cursor(CURSOR_POINT)
+                if self.selected_shape.area < self.limit_size(self.selected_shape.label):
+                    try:
+                        self.parent().window().remove_label(self.selected_shape)
+                        self.shapes.remove(self.selected_shape)
+                        self.update()
+                    except:
+                        pass
             else:
                 self.override_cursor(CURSOR_GRAB)
         elif ev.button() == Qt.LeftButton:
             pos = self.transform_pos(ev.pos())
             if self.drawing():
                 self.handle_drawing(pos)
+
+                if len(self.shapes) == 0:
+                    return
+
+                if self.shapes[-1].area < self.limit_size(self.shapes[-1].label):
+                    self.parent().window().remove_label(self.shapes[-1])
+                    self.shapes.remove(self.shapes[-1])
+                    self.update()
             else:
                 # pan
                 QApplication.restoreOverrideCursor()


### PR DESCRIPTION
크기가 작은 박스를 생성했을 때, 간혹 의도하지 않은 박스가 사라지는 현상이 발생했었음
삭제 대상이 되는 객체 인덱스가 정확하지 않아서 발생되는 문제로 파악됨.
옳바른 객체를 삭제할 수 있도록 수정함.


